### PR TITLE
update schema to align with numerical fields

### DIFF
--- a/app/schema.py
+++ b/app/schema.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, StringConstraints
 
@@ -22,17 +22,46 @@ class OuterOp(Enum):
     EQ = "="
 
 
-class InnerContent(BaseModel):
+class InnerStrContent(BaseModel):
     field: Annotated[str, StringConstraints(min_length=1, max_length=64)]
-    value: (
-        list[Annotated[str, StringConstraints(min_length=1, max_length=128)]]
-        | Annotated[float, Field(ge=0, le=32872)]
-    )
+    value: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]]
+
+
+class InnerAgeDxContent(BaseModel):
+    field: Literal["cases.diagnoses.age_at_diagnosis"]
+    value: Annotated[int, Field(ge=0, le=32872)]
+
+
+class InnerYearDxContent(BaseModel):
+    field: Literal["cases.diagnoses.year_of_diagnosis"]
+    value: Annotated[int, Field(ge=1900, le=2050)]
+
+
+class InnerCigDayContent(BaseModel):
+    field: Literal["cases.exposures.cigarettes_per_day"]
+    value: Annotated[int, Field(ge=0, le=999999)]
+
+
+class InnerPackYrContent(BaseModel):
+    field: Literal["cases.exposures.pack_years_smoked"]
+    value: Annotated[int, Field(ge=0, le=999999)]
+
+
+class InnerCigStrtContent(BaseModel):
+    field: Literal["cases.exposures.tobacco_smoking_onset_year"]
+    value: Annotated[int, Field(ge=1900, le=2050)]
 
 
 class Inner(BaseModel):
     op: InnerOp
-    content: InnerContent
+    content: (
+        InnerStrContent
+        | InnerAgeDxContent
+        | InnerYearDxContent
+        | InnerCigDayContent
+        | InnerPackYrContent
+        | InnerCigStrtContent
+    )
 
 
 class Middle(BaseModel):


### PR DESCRIPTION
initial version of tool will only support cohorts that are possible via standard/default fields within cohort builder, this PR updates the schema to use the right numerical integer values for those fields